### PR TITLE
Adding CoreferenceProcessor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Install NeuralCoref
       run: |
-        git install git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref
+        pip install git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref
 
     - name: Test with pytest and run coverage
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,10 @@ jobs:
         cd forte-wrappers
         pip install src/spacy
 
+    - name: Install NeuralCoref
+      run: |
+        git install git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref
+
     - name: Test with pytest and run coverage
       run: |
         coverage run -m pytest tests/

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -27,8 +27,8 @@ from forte.common.configuration import Config
 from forte.data.data_pack import DataPack
 from forte.processors.base import PackProcessor
 
-from ft.onto.base_ontology import CoreferenceGroup, Token, EntityMention
-from ftx.medical.clinical_ontology import MedicalEntityMention, MedicalArticle
+from ft.onto.base_ontology import CoreferenceGroup, Token
+from ftx.medical.clinical_ontology import MedicalArticle
 
 __all__ = [
     "CoreferenceProcessor",

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -14,11 +14,11 @@
 """
 Coreference Processor
 """
-from typing import Dict, Optional, Set
+from typing import Dict, Set #, Optional
 import importlib
 
 import spacy
-from spacy.language import Language
+# from spacy.language import Language
 
 import neuralcoref
 
@@ -50,7 +50,7 @@ class CoreferenceProcessor(PackProcessor):
 
     def __init__(self):
         super().__init__()
-        self.spacy_nlp: Optional[Language] = None  # TODO: a more elegant way
+        self.spacy_nlp = None  # TODO: a more elegant way
 
     def set_up(self, configs: Config):
         # TODO: remove these comments

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -14,10 +14,11 @@
 """
 Coreference Processor
 """
-from typing import Dict, Set #, Optional
+from typing import Dict, Set  # , Optional
 import importlib
 
 import spacy
+
 # from spacy.language import Language
 
 import neuralcoref

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -14,13 +14,13 @@
 """
 Coreference Processor
 """
-from lib2to3.pgen2 import token
 from typing import Dict, Optional, Set
 import importlib
-from numpy import append
 
 import spacy
 from spacy.language import Language
+
+import neuralcoref
 
 from forte.common import Resources, ProcessExecutionException
 from forte.common.configuration import Config
@@ -53,8 +53,6 @@ class CoreferenceProcessor(PackProcessor):
         self.spacy_nlp: Optional[Language] = None  # TODO: a more elegant way
 
     def set_up(self, configs: Config):
-        import neuralcoref
-
         # TODO: remove these comments
         # TODO: a more elegant way
         # self.spacy_nlp = self.resources.get("spacy_processor").nlp # borrow nlp from SpacyProcessor

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -17,8 +17,6 @@ Coreference Processor
 from typing import Dict, Set
 import importlib
 
-from fortex.spacy.spacy_processors import load_lang_model
-
 import neuralcoref
 
 from forte.common import Resources, ProcessExecutionException
@@ -28,6 +26,8 @@ from forte.processors.base import PackProcessor
 
 from ft.onto.base_ontology import CoreferenceGroup
 from ftx.medical.clinical_ontology import MedicalArticle
+
+from fortex.spacy.spacy_processors import load_lang_model
 
 __all__ = [
     "CoreferenceProcessor",

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -14,10 +14,11 @@
 """
 Coreference Processor
 """
-import os
-import re
-from typing import Dict, List, Set
+from typing import Dict, Optional, Set
 import importlib
+from boto import config
+
+from spacy.language import Language
 
 from forte.common import Resources, ProcessExecutionException
 from forte.common.configuration import Config
@@ -34,14 +35,17 @@ __all__ = [
 
 class CoreferenceProcessor(PackProcessor):
     r"""
-    TODO: Add docstring
+    Implementation of this CoreferenceProcessor has been based on huggingface
+    NeuralCoref. Note that official released NeuralCoref uses a dated spaCy
+    version (2.1), which can cause segmentation fault with the spaCy we use (2.3).
+    Please install NeuralCoref by building from source:
+
+    https://github.com/huggingface/neuralcoref
     """
 
     def __init__(self):
         super().__init__()
-        # TODO
-        self.coref = None  # TODO: add type
-        self.spacy_nlp = None  # TODO: find an elegant way to set this.
+        self.spacy_nlp: Optional[Language] = None  # TODO: a more elegant way
 
     def set_up(self, configs: Config):
         import neuralcoref
@@ -52,8 +56,19 @@ class CoreferenceProcessor(PackProcessor):
                 "The SpaCy pipeline is not initialized, maybe you "
                 "haven't called the initialization function."
             )
-        kwargs = {}  # TODO
-        neuralcoref.add_to_pipe(self.spacy_nlp)
+
+        model = configs.model
+        cfg_inference = {
+            "greedyness": configs.greedyness,
+            "max_dist": configs.max_dist,
+            "max_dist_match": configs.max_dist_match,
+            "blacklist": configs.blacklist,
+            "store_scores": configs.store_scores,
+            "conv_dict": configs.conv_dict,
+        }
+        neuralcoref.add_to_pipe(
+            self.spacy_nlp, model=model, cfg_inference=cfg_inference
+        )
 
     def initialize(self, resources: Resources, configs: Config):
         super().initialize(resources, configs)
@@ -64,11 +79,12 @@ class CoreferenceProcessor(PackProcessor):
         TODO: Add docstring
         """
         path_str, module_str = self.configs.entry_type.rsplit(".", 1)
-        # By default, path_str would be ft.onto.base_ontology and module_str would be Document # TODO: check
+        # By default, path_str would be ft.onto.base_ontology
+        # and module_str would be Document # TODO: check
 
         mod = importlib.import_module(path_str)
-        entry = getattr(mod, module_str)
-        for entry_specified in input_pack.get(entry_type=entry):
+        entry_type = getattr(mod, module_str)
+        for entry_specified in input_pack.get(entry_type=entry_type):
             result = self.spacy_nlp(entry_specified.text)
             tokens = [(token) for token in input_pack.get(Token, entry_specified)]
 
@@ -100,14 +116,59 @@ class CoreferenceProcessor(PackProcessor):
 
                     article.coref_groups.append(group)
 
+    # @classmethod
+    # def default_configs(cls):
+    #     r"""
+    #     This defines a basic config structure for `CoreferenceProcessor`.
+
+    #     Following are the keys for this dictionary:
+    #      - `entry_type`: input entry type,
+    #      - `model`: the neural net model to be used by NeuralCoref. If set to True
+    #         (default), a new instance will be created with `NeuralCoref.Model()`
+    #         in NeuralCoref.from_disk() or NeuralCoref.from_bytes().
+    #      - `cfg_inference`: A dict of configuration of inference. If set to an empty
+    #         dict, the default configuration in NeuralCoref will be used. Available
+    #         entries: `greedyness` (default 0.5), `max_dist` (default 50),
+    #         `max_dist_match` (default 500), `blacklist` (default True),
+    #         `store_scores` (default True), `conv_dict` (default None),
+
+    #     Returns: A dictionary with the default config for this processor.
+    #     """
+    #     return {
+    #         # TODO: remove unnecessaries
+    #         "entry_type": "ft.onto.base_ontology.Document",
+    #         "model": True,
+    #         "cfg_inference": {},
+    #     }
+
     @classmethod
     def default_configs(cls):
         r"""
-        TODO: Add docstring
+        This defines a basic config structure for `CoreferenceProcessor`.
+
+        Following are the keys for this dictionary:
+         - `entry_type`: Input entry type. Default `"ft.onto.base_ontology.Document"`.
+         - `model`: the neural net model to be used by NeuralCoref. If set to `True`
+            (default), a new instance will be created with `NeuralCoref.Model()`
+            in `NeuralCoref.from_disk()` or `NeuralCoref.from_bytes()`.
+         - `greedyness`: TODO. Default `0.5`.
+         - `max_dist`: TODO. Default `50`.
+         - `max_dist_match`: TODO. Default `500`.
+         - `blacklist`: TODO. Default `True`.
+         - `store_scores`: TODO. Default `True`
+         - `conv_dict`: TODO. Default `None`.
+
+        Returns: A dictionary with the default config for this processor.
         """
         return {
-            # TODO: remove unnecessaries
             "entry_type": "ft.onto.base_ontology.Document",
+            "model": True,
+            "greedyness": 0.5,
+            "max_dist": 50,
+            "max_dist_match": 500,
+            "blacklist": True,
+            "store_scores": True,
+            "conv_dict": None,
         }
 
     def expected_types_and_attributes(self):
@@ -118,22 +179,19 @@ class CoreferenceProcessor(PackProcessor):
         :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
         the pipeline.
         """
-        return {
-            # TODO
-        }
+        return {"ft.onto.base_ontology.Document": set()}
 
     def record(self, record_meta: Dict[str, Set[str]]):
         r"""
         Method to add output type record of `CoreferenceProcessor` which
         is `"ftx.medical.clinical_ontology.MedicalArticle"` with attribute
-        `coref_clusters`
+        `coref_groups` and `has_coref`
         to :attr:`forte.data.data_pack.Meta.record`.
 
         Args:
             record_meta: the field in the datapack for type record that need to
                 fill in for consistency checking.
         """  # TODO: check docstring
-        # TODO
         record_meta["ftx.medical.clinical_ontology.MedicalArticle"] = {
             "coref_groups",
             "has_coref",

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -39,8 +39,8 @@ class CoreferenceProcessor(PackProcessor):
     r"""
     Implementation of this CoreferenceProcessor has been based on huggingface
     NeuralCoref. You can find more details in the original repo.
-    
-    Note that official released NeuralCoref uses a dated spaCy
+
+    Note that the NeuralCoref package from PyPI uses a dated spaCy
     version (2.1), which can cause segmentation fault with the spaCy we use (2.3).
     Please install NeuralCoref by building from source.
 
@@ -154,17 +154,17 @@ class CoreferenceProcessor(PackProcessor):
 
         Following are the keys for this dictionary:
          - `entry_type`: Input entry type. Default: `"ft.onto.base_ontology.Document"`.
-         - `mention_type`: Output mention type. 
+         - `mention_type`: Output mention type.
             Default: `"ftx.medical.clinical_ontology.MedicalEntityMention"`.
             It can also be set to `"ft.onto.base_ontology.EntityMention"`.
          - `model`: the neural net model to be used by NeuralCoref. If set to `True`,
             a new instance will be created with `NeuralCoref.Model()`. Default: `True`.
             in `NeuralCoref.from_disk()` or `NeuralCoref.from_bytes()`.
-         - `greedyness` (`float`): A number between 0 and 1 determining how greedy 
-            the model is about making coreference decisions 
+         - `greedyness` (`float`): A number between 0 and 1 determining how greedy
+            the model is about making coreference decisions
             (more greedy means more coreference links). Default: `0.5`.
-         - `max_dist` (`int`): How many mentions back to look when considering possible 
-            antecedents of the current mention. Decreasing the value will cause 
+         - `max_dist` (`int`): How many mentions back to look when considering possible
+            antecedents of the current mention. Decreasing the value will cause
             the system to run faster but less accurately. Default: `50`.
          - `max_dist_match` (`int`): The system will consider linking the current mention
             to a preceding one further than max_dist away if they share a noun or

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -1,0 +1,90 @@
+# Copyright 2022 The Forte Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Coreference Processor
+"""
+import os
+import re
+from typing import Dict, List, Set
+
+from forte.common import Resources
+from forte.common.configuration import Config
+from forte.data.data_pack import DataPack
+from forte.processors.base import PackProcessor
+
+# from ft.onto.base_ontology import TODO
+# from ftx.medical.clinical_ontology import TODO
+
+__all__ = [
+    "CoreferenceProcessor",
+]
+
+
+class CoreferenceProcessor(PackProcessor):
+    r"""
+    TODO: Add docstring
+    """
+
+    def __init__(self):
+        super().__init__()
+        # TODO
+
+    def set_up(self, configs: Config):
+        pass
+        # TODO
+
+    def initialize(self, resources: Resources, configs: Config):
+        super().initialize(resources, configs)
+        self.set_up(configs)
+
+    def _process(self, input_pack: DataPack):
+        r"""
+        TODO: Add docstring
+        """
+        pass
+        # TODO    
+
+    @classmethod
+    def default_configs(cls):
+        r"""
+        TODO: Add docstring
+        """
+        return {
+            # TODO
+        }
+
+    def expected_types_and_attributes(self):
+        r"""
+        Method to add user specified expected type which would be checked
+        before running the processor if the pipeline is initialized with
+        `enforce_consistency=True` or
+        :meth:`~forte.pipeline.Pipeline.enforce_consistency` was enabled for
+        the pipeline.
+        """
+        return {
+            # TODO
+        }
+
+    def record(self, record_meta: Dict[str, Set[str]]):
+        r"""
+        Method to add output type record of `CoreferenceProcessor` which
+        is `"ftx.onto.clinical.TODO"` with attribute
+        `TODO`
+        to :attr:`forte.data.data_pack.Meta.record`.
+
+        Args:
+            record_meta: the field in the datapack for type record that need to
+                fill in for consistency checking.
+        """
+        # TODO

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -26,7 +26,7 @@ from forte.common.configuration import Config
 from forte.data.data_pack import DataPack
 from forte.processors.base import PackProcessor
 
-from ft.onto.base_ontology import CoreferenceGroup, Token
+from ft.onto.base_ontology import CoreferenceGroup
 from ftx.medical.clinical_ontology import MedicalArticle
 
 __all__ = [
@@ -49,13 +49,9 @@ class CoreferenceProcessor(PackProcessor):
 
     def __init__(self):
         super().__init__()
-        self.spacy_nlp = None  # TODO: a more elegant way
+        self.spacy_nlp = None
 
     def set_up(self, configs: Config):
-        # TODO: remove these comments
-        # TODO: a more elegant way
-        # borrow nlp from SpacyProcessor
-        # self.spacy_nlp = self.resources.get("spacy_processor").nlp
         self.spacy_nlp = spacy.load(configs.lang)
 
         if self.spacy_nlp is None:
@@ -104,15 +100,6 @@ class CoreferenceProcessor(PackProcessor):
         for entry_specified in input_pack.get(entry_type=entry_type):
             result = self.spacy_nlp(entry_specified.text)
 
-            # TODO: remove these comments
-            # Marker155326
-            # When tokenization is different from SpacyProcessor, this will be a bug:
-            token_begins = []
-            token_ends = []
-            for token in input_pack.get(Token, entry_specified):
-                token_begins.append(token.begin)
-                token_ends.append(token.end)
-
             article = MedicalArticle(
                 pack=input_pack,
                 begin=entry_specified.span.begin,
@@ -135,8 +122,8 @@ class CoreferenceProcessor(PackProcessor):
                     for mention in cluster.mentions:
                         mention = mention_type(
                             input_pack,
-                            token_begins[mention.start],
-                            token_ends[mention.end - 1],
+                            mention.start_char,
+                            mention.end_char,
                         )
                         mentions.append(mention)
 

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -38,10 +38,13 @@ __all__ = [
 class CoreferenceProcessor(PackProcessor):
     r"""
     Implementation of this CoreferenceProcessor has been based on huggingface
-    NeuralCoref. Note that official released NeuralCoref uses a dated spaCy
+    NeuralCoref. You can find more details in the original repo.
+    
+    Note that official released NeuralCoref uses a dated spaCy
     version (2.1), which can cause segmentation fault with the spaCy we use (2.3).
-    Please install NeuralCoref by building from source:
+    Please install NeuralCoref by building from source.
 
+    Referred repository link:
     https://github.com/huggingface/neuralcoref
     """
 
@@ -83,9 +86,9 @@ class CoreferenceProcessor(PackProcessor):
     def _process(self, input_pack: DataPack):
         r"""
         Coreference resolution is done by
-        a spaCy pipeline with `NeuralCoref` in it.
+        a spaCy pipeline with `NeuralCoref` added.
 
-        We translate the output to `CoreferenceGroup` and
+        Then we translate the output to `CoreferenceGroup` and
         `MedicalEntityMention`
         """
 

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -17,7 +17,7 @@ Coreference Processor
 from typing import Dict, Set
 import importlib
 
-import spacy
+from fortex.spacy.spacy_processors import load_lang_model
 
 import neuralcoref
 
@@ -52,7 +52,7 @@ class CoreferenceProcessor(PackProcessor):
         self.spacy_nlp = None
 
     def set_up(self, configs: Config):
-        self.spacy_nlp = spacy.load(configs.lang)
+        self.spacy_nlp = load_lang_model(configs.lang)
 
         if self.spacy_nlp is None:
             raise ProcessExecutionException(

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -55,7 +55,8 @@ class CoreferenceProcessor(PackProcessor):
     def set_up(self, configs: Config):
         # TODO: remove these comments
         # TODO: a more elegant way
-        # self.spacy_nlp = self.resources.get("spacy_processor").nlp # borrow nlp from SpacyProcessor
+        # borrow nlp from SpacyProcessor
+        # self.spacy_nlp = self.resources.get("spacy_processor").nlp
         self.spacy_nlp = spacy.load(configs.lang)
 
         if self.spacy_nlp is None:

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -14,12 +14,10 @@
 """
 Coreference Processor
 """
-from typing import Dict, Set  # , Optional
+from typing import Dict, Set
 import importlib
 
 import spacy
-
-# from spacy.language import Language
 
 import neuralcoref
 

--- a/fortex/health/processors/coreference_processor.py
+++ b/fortex/health/processors/coreference_processor.py
@@ -200,7 +200,7 @@ class CoreferenceProcessor(PackProcessor):
         Args:
             record_meta: the field in the datapack for type record that need to
                 fill in for consistency checking.
-        """  # TODO: check docstring
+        """
         record_meta["ftx.medical.clinical_ontology.MedicalArticle"] = {
             "coref_groups",
             "has_coref",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ git+https://git@github.com/asyml/forte-wrappers.git#egg=forte.huggingface&subdir
 dataclasses~=0.8; python_version < '3.7'
 setuptools~=57.0.0
 transformers~=4.2.2
+# neuralcoref (build from source) for CoreferenceProcessor
+git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ setuptools~=57.0.0
 transformers~=4.2.2
 # neuralcoref (build from source) for CoreferenceProcessor
 git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref
+cython>=0.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ dataclasses~=0.8; python_version < '3.7'
 setuptools~=57.0.0
 transformers~=4.2.2
 
-spacy>=2.3.0, <=2.3.5
+# spacy>=2.3.0, <=2.3.5 # will be installed by forte.spacy
 cython>=0.25
 pytest
 # It is annoying that if we install neuralcoref and spacy at the same

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,8 @@ git+https://git@github.com/asyml/forte-wrappers.git#egg=forte.huggingface&subdir
 dataclasses~=0.8; python_version < '3.7'
 setuptools~=57.0.0
 transformers~=4.2.2
-# neuralcoref (build from source) for CoreferenceProcessor
-git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref
-cython>=0.25
+
+# It is annoying that if we install neuralcoref and spacy at the same
+# time, neuralcoref will throw "Cython failed" during building.
+# Therefore, we must install neuralcoref after spacy is installed.
+# git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ dataclasses~=0.8; python_version < '3.7'
 setuptools~=57.0.0
 transformers~=4.2.2
 
+spacy>=2.3.0, <=2.3.5
 # It is annoying that if we install neuralcoref and spacy at the same
 # time, neuralcoref will throw "Cython failed" during building.
 # Therefore, we must install neuralcoref after spacy is installed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,8 @@ setuptools~=57.0.0
 transformers~=4.2.2
 
 spacy>=2.3.0, <=2.3.5
+cython>=0.25
+pytest
 # It is annoying that if we install neuralcoref and spacy at the same
 # time, neuralcoref will throw "Cython failed" during building.
 # Therefore, we must install neuralcoref after spacy is installed.

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ setuptools.setup(
         'dataclasses~=0.7;python_version<"3.7"',
         "fastapi==0.65.2",
         "uvicorn==0.14.0",
-        "cython>=0.25",
-        "neuralcoref @ git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref",
     ],
     extras_require={
         "test": [
@@ -50,6 +48,10 @@ setuptools.setup(
             "testfixtures",
             "transformers==4.2.2",
             "protobuf==3.19.4",
+            # It is annoying that if we install neuralcoref and spacy at the same
+            # time, neuralcoref will throw "Cython failed" during building.
+            # Therefore, we must install neuralcoref after spacy is installed.
+            # "neuralcoref @ git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref",
         ],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         'dataclasses~=0.7;python_version<"3.7"',
         "fastapi==0.65.2",
         "uvicorn==0.14.0",
+        "cython>=0.25",
         "neuralcoref @ git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
         'dataclasses~=0.7;python_version<"3.7"',
         "fastapi==0.65.2",
         "uvicorn==0.14.0",
-        "spacy>=2.3.0, <=2.3.5",
+        # "spacy>=2.3.0, <=2.3.5", # will be installed by forte.spacy
         "cython>=0.25",
         "pytest",
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setuptools.setup(
         'dataclasses~=0.7;python_version<"3.7"',
         "fastapi==0.65.2",
         "uvicorn==0.14.0",
+        "neuralcoref @ git+https://git@github.com/huggingface/neuralcoref.git@4.0.0#egg=neuralcoref",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setuptools.setup(
         "fastapi==0.65.2",
         "uvicorn==0.14.0",
         "spacy>=2.3.0, <=2.3.5",
+        "cython>=0.25",
+        "pytest",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -6,23 +6,22 @@ import setuptools
 long_description = (Path(__file__).parent / "README.md").read_text()
 
 if sys.version_info < (3, 6):
-    sys.exit('Python>=3.6 is required by forte-medical.')
+    sys.exit("Python>=3.6 is required by forte-medical.")
 
 setuptools.setup(
     name="forte.health",
-    version='0.1.0',
+    version="0.1.0",
     url="https://github.com/asyml/ForteHealth",
     description="NLP pipeline framework for biomedical and clinical domains",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    license='Apache License Version 2.0',
+    license="Apache License Version 2.0",
     packages=setuptools.find_namespace_packages(
-        include=['fortex.health', 'ftx.*'],
-        exclude=["scripts*", "examples*", "tests*"]
+        include=["fortex.health", "ftx.*"], exclude=["scripts*", "examples*", "tests*"]
     ),
     namespace_packages=["fortex"],
     install_requires=[
-        'forte~=0.2.0',
+        "forte~=0.2.0",
         "sortedcontainers==2.1.0",
         "numpy>=1.16.6",
         "jsonpickle==1.4",
@@ -41,6 +40,7 @@ setuptools.setup(
         'dataclasses~=0.7;python_version<"3.7"',
         "fastapi==0.65.2",
         "uvicorn==0.14.0",
+        "spacy>=2.3.0, <=2.3.5",
     ],
     extras_require={
         "test": [
@@ -55,12 +55,12 @@ setuptools.setup(
         ],
     },
     entry_points={
-        'console_scripts': [
+        "console_scripts": [
             "forte-medical-train=forte_medical_cli.train:main",
             "forte-medical-process=forte_medical_cli.process:main",
             "forte-medical-evaluate=forte_medical_cli.evaluate:main",
         ]
     },
     include_package_data=True,
-    python_requires='>=3.6'
+    python_requires=">=3.6",
 )

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -26,8 +26,6 @@ from ftx.medical.clinical_ontology import MedicalArticle
 from ft.onto.base_ontology import (
     Token,
 )
-
-from fortex.spacy import SpacyProcessor
 from fortex.health.processors.coreference_processor import (
     CoreferenceProcessor,
 )
@@ -38,10 +36,6 @@ class TestCoreferenceProcessor(unittest.TestCase):
     def setUp(self):
         self.pl = Pipeline[DataPack](enforce_consistency=True)
         self.pl.set_reader(StringReader())
-        self.pl.add(
-            SpacyProcessor(),
-            {"processors": ["sentence", "tokenize"], "lang": "en_core_web_sm"},
-        )
         self.pl.add(
             CoreferenceProcessor(),
             {

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -80,14 +80,14 @@ class TestCoreferenceProcessor(unittest.TestCase):
 
     @data(
         "ADDENDUM:\n",
-        "RADIOLOGIC STUDIES: Radiologic studies also included ",
-        "a chest CT, which confirmed cavitary lesions ",
-        "in the left lung apex consistent with infectious process/tuberculosis.\n",
-        "This also moderate-sized left pleural effusion.\n",
-        "HEAD CT: Head CT showed no intracranial hemorrhage and no mass effect, ",
-        "but old infarction consistent with past medical history.\n",
-        "ABDOMINAL CT:  Abdominal CT showed no lesions of T10 and sacrum ",
-        "most likely secondary to steoporosis.\n",
+        "RADIOLOGIC STUDIES: Radiologic studies also included "
+        "a chest CT, which confirmed cavitary lesions "
+        "in the left lung apex consistent with infectious process/tuberculosis.\n"
+        "This also moderate-sized left pleural effusion.\n"
+        "HEAD CT: Head CT showed no intracranial hemorrhage and no mass effect, "
+        "but old infarction consistent with past medical history.\n"
+        "ABDOMINAL CT:  Abdominal CT showed no lesions of T10 and sacrum "
+        "most likely secondary to steoporosis.\n"
         "These can be followed by repeat imaging as an outpatient.",
     )
     def test_medical_notes(self, input_data):

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -16,7 +16,7 @@ Unit tests for CoreferenceProcessor
 """
 
 import unittest
-from ddt import data
+from ddt import data, ddt
 
 from forte.data.data_pack import DataPack
 from forte.data.readers import StringReader
@@ -32,7 +32,7 @@ from fortex.health.processors.coreference_processor import (
     CoreferenceProcessor,
 )
 
-
+@ddt
 class TestCoreferenceProcessor(unittest.TestCase):
     def setUp(self):
         self.pl = Pipeline[DataPack](enforce_consistency=True)

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -16,7 +16,7 @@ Unit tests for CoreferenceProcessor
 """
 
 import unittest
-from ddt import data, ddt
+from ddt import data
 
 from forte.data.data_pack import DataPack
 from forte.data.readers import StringReader
@@ -58,24 +58,6 @@ class TestCoreferenceProcessor(unittest.TestCase):
         )
 
         self.pl.initialize()
-
-    @data("My sister has a dog. She loves him.")
-    def test_daily_language(self, input_data):
-        for pack in self.pl.process_dataset(input_data):
-            for article in pack.get(MedicalArticle):
-                has_coref = article.has_coref
-                assert has_coref == True
-
-                coref_groups = article.coref_groups
-                output_list = []
-                check_list = [["My sister", "She"], ["a dog", "him"]]
-                for group in coref_groups:
-                    members = [member for member in group.get_members()]
-                    members = sorted(members, key=lambda x: x.begin)
-
-                    mention_texts = [member.text for member in members]
-                    output_list.append(mention_texts)
-                assert output_list == check_list
 
     @data("My sister has a dog. She loves him.")
     def test_daily_language(self, input_data):

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -65,7 +65,7 @@ class TestCoreferenceProcessor(unittest.TestCase):
         for pack in self.pl.process_dataset(input_data):
             for article in pack.get(MedicalArticle):
                 has_coref = article.has_coref
-                assert has_coref == True
+                assert has_coref is True
 
                 coref_groups = article.coref_groups
                 output_list = []
@@ -94,7 +94,7 @@ class TestCoreferenceProcessor(unittest.TestCase):
         for pack in self.pl.process_dataset(input_data):
             for article in pack.get(MedicalArticle):
                 has_coref = article.has_coref
-                assert has_coref == True
+                assert has_coref is True
 
                 coref_groups = article.coref_groups
                 output_list = []

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -1,0 +1,121 @@
+# Copyright 2022 The Forte Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for CoreferenceProcessor
+"""
+
+import unittest
+from ddt import data, ddt
+
+from forte.data.data_pack import DataPack
+from forte.data.readers import StringReader
+from forte.pipeline import Pipeline
+
+from ftx.medical.clinical_ontology import MedicalArticle
+from ft.onto.base_ontology import (
+    Token,
+)
+
+from fortex.spacy import SpacyProcessor
+from fortex.health.processors.coreference_processor import (
+    CoreferenceProcessor,
+)
+
+
+class TestCoreferenceProcessor(unittest.TestCase):
+    def setUp(self):
+        self.pl = Pipeline[DataPack](enforce_consistency=True)
+        self.pl.set_reader(StringReader())
+        self.pl.add(
+            SpacyProcessor(),
+            {"processors": ["sentence", "tokenize"], "lang": "en_core_web_sm"},
+        )
+        self.pl.add(
+            CoreferenceProcessor(),
+            {
+                "entry_type": "ft.onto.base_ontology.Document",
+                "mention_type": "ftx.medical.clinical_ontology.MedicalEntityMention",
+                "lang": "en_core_web_sm",
+                "model": True,
+                "greedyness": 0.5,
+                "max_dist": 50,
+                "max_dist_match": 500,
+                "blacklist": True,
+                "store_scores": True,
+                "conv_dict": None,
+            },
+        )
+
+        self.pl.initialize()
+
+    @data("My sister has a dog. She loves him.")
+    def test_daily_language(self, input_data):
+        for pack in self.pl.process_dataset(input_data):
+            for article in pack.get(MedicalArticle):
+                has_coref = article.has_coref
+                assert has_coref == True
+
+                coref_groups = article.coref_groups
+                output_list = []
+                check_list = [["My sister", "She"], ["a dog", "him"]]
+                for group in coref_groups:
+                    members = [member for member in group.get_members()]
+                    members = sorted(members, key=lambda x: x.begin)
+
+                    mention_texts = [member.text for member in members]
+                    output_list.append(mention_texts)
+                assert output_list == check_list
+
+    @data("My sister has a dog. She loves him.")
+    def test_daily_language(self, input_data):
+        for pack in self.pl.process_dataset(input_data):
+            for article in pack.get(MedicalArticle):
+                has_coref = article.has_coref
+                assert has_coref == True
+
+                coref_groups = article.coref_groups
+                output_list = []
+                check_list = [["My sister", "She"], ["a dog", "him"]]
+                for group in coref_groups:
+                    members = [member for member in group.get_members()]
+                    members = sorted(members, key=lambda x: x.begin)
+
+                    mention_texts = [member.text for member in members]
+                    output_list.append(mention_texts)
+                assert output_list == check_list
+
+    @data(
+        """ADDENDUM:
+RADIOLOGIC STUDIES: Radiologic studies also included a chest CT, which confirmed cavitary lesions in the left lung apex consistent with infectious process/tuberculosis.
+This also moderate-sized left pleural effusion.
+HEAD CT: Head CT showed no intracranial hemorrhage and no mass effect, but old infarction consistent with past medical history.
+ABDOMINAL CT:  Abdominal CT showed no lesions of T10 and sacrum most likely secondary to steoporosis.
+These can be followed by repeat imaging as an outpatient."""
+    )
+    def test_medical_notes(self, input_data):
+        for pack in self.pl.process_dataset(input_data):
+            for article in pack.get(MedicalArticle):
+                has_coref = article.has_coref
+                assert has_coref == True
+
+                coref_groups = article.coref_groups
+                output_list = []
+                check_list = [["HEAD CT", "Head CT", "Abdominal CT"]]
+                for group in coref_groups:
+                    members = [member for member in group.get_members()]
+                    members = sorted(members, key=lambda x: x.begin)
+
+                    mention_texts = [member.text for member in members]
+                    output_list.append(mention_texts)
+                assert output_list == check_list

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -79,7 +79,7 @@ class TestCoreferenceProcessor(unittest.TestCase):
                 assert output_list == check_list
 
     @data(
-        "ADDENDUM:\n",
+        "ADDENDUM:\n"
         "RADIOLOGIC STUDIES: Radiologic studies also included "
         "a chest CT, which confirmed cavitary lesions "
         "in the left lung apex consistent with infectious process/tuberculosis.\n"

--- a/tests/forte_medical/processors/coreference_processor_test.py
+++ b/tests/forte_medical/processors/coreference_processor_test.py
@@ -32,6 +32,7 @@ from fortex.health.processors.coreference_processor import (
     CoreferenceProcessor,
 )
 
+
 @ddt
 class TestCoreferenceProcessor(unittest.TestCase):
     def setUp(self):
@@ -78,12 +79,16 @@ class TestCoreferenceProcessor(unittest.TestCase):
                 assert output_list == check_list
 
     @data(
-        """ADDENDUM:
-RADIOLOGIC STUDIES: Radiologic studies also included a chest CT, which confirmed cavitary lesions in the left lung apex consistent with infectious process/tuberculosis.
-This also moderate-sized left pleural effusion.
-HEAD CT: Head CT showed no intracranial hemorrhage and no mass effect, but old infarction consistent with past medical history.
-ABDOMINAL CT:  Abdominal CT showed no lesions of T10 and sacrum most likely secondary to steoporosis.
-These can be followed by repeat imaging as an outpatient."""
+        "ADDENDUM:\n",
+        "RADIOLOGIC STUDIES: Radiologic studies also included ",
+        "a chest CT, which confirmed cavitary lesions ",
+        "in the left lung apex consistent with infectious process/tuberculosis.\n",
+        "This also moderate-sized left pleural effusion.\n",
+        "HEAD CT: Head CT showed no intracranial hemorrhage and no mass effect, ",
+        "but old infarction consistent with past medical history.\n",
+        "ABDOMINAL CT:  Abdominal CT showed no lesions of T10 and sacrum ",
+        "most likely secondary to steoporosis.\n",
+        "These can be followed by repeat imaging as an outpatient.",
     )
     def test_medical_notes(self, input_data):
         for pack in self.pl.process_dataset(input_data):


### PR DESCRIPTION
This PR fixes [#15](https://github.com/asyml/ForteHealth/issues/15). 

### Description of changes
Added `CoreferenceProcessor` and its unit test. Updated `setup.py`, `requirements.txt`, and ci workflow.
- `CoreferenceProcessor`: a wrapper for [`NeuralCoref`](https://github.com/huggingface/neuralcoref). It translates the original output to `CoreferenceGroup` and `MedicalEntityMention` and puts them into data pack.
- Unit test: tests on daily language and medical notes.
- `setup.py` and `requirements.txt`: added `cython`, and `pytest`, which are dependencies of `neuralcoref`. 
- CI workflow: added a stage called "Install NeuralCoref", after the installation of `fortex.spacy`. Since `neuralcoref` needs to be built from source. See the reason in [NeuralCoref Installation Issue](#NeuralCoref-Installation-Issue).

### Possible influences of this PR.
- Be careful with the "Install NeuralCoref" workflow stage. It needs to be placed after the installation of `cython` and  `fortex.spacy`.

### Test Conducted
Tested on new unit test.

### NeuralCoref Installation Issue
Installing `neuralcoref` from PyPI causes segmentation fault, since the binary file is built with `spacy` 2.1, while the `spacy` used by `forte.spacy` is 2.3. We need to build from source to use customized `spacy` version.

Building from source needs `spacy` and `cython` being already installed. Putting `neuralcoref` together with `spacy` and `cython` in `requirements.txt` and `setup.py` can cause "Cython failed" exception, since building binary files comes ahead of the installation of `cython` and `spacy`. Therefore we need to delay the installation of `neuralcoref`.

But I don't know how to do this in an elegant way. `requirements.txt` seems not to support this kind of two stage installation. `setup.py` seems to support, but I don't know how to. So I added a new stage in CI after the installation of `requirements.txt` and `fortex.spacy`.