### PR TITLE
Added new temporal annotations

### DIFF
--- a/fortex/health/ontology_specs/clinical_ontology.json
+++ b/fortex/health/ontology_specs/clinical_ontology.json
@@ -440,7 +440,7 @@
      {
       "entry_name": "ftx.medical.clinical_ontology.NormalizedTemporalForm",
       "parent_entry": "forte.data.ontology.top.Annotation",
-      "description": "A span based annotation `TemporalTag`, used to represent temporal tags of words",
+      "description": "A span based annotation `NormalizedTemporalForm`, used to represent normalized forms of temporal tokens",
       "attributes": [
         {
           "name": "type",

--- a/fortex/health/ontology_specs/clinical_ontology.json
+++ b/fortex/health/ontology_specs/clinical_ontology.json
@@ -404,7 +404,7 @@
       {
       "entry_name": "ftx.medical.clinical_ontology.Abbreviation",
       "parent_entry": "forte.data.ontology.top.Annotation",
-      "description": "A span based annotation `Abbreviation`, used to represent an abbreviated token..",
+      "description": "A span based annotation `Abbreviation`, used to represent an abbreviated token",
       "attributes": [
         {
           "name": "long_form",
@@ -425,6 +425,32 @@
       ],
       "parent_type": "ft.onto.base_ontology.Phrase",
       "child_type": "ft.onto.base_ontology.Phrase"
+     },
+     {
+      "entry_name": "ftx.medical.clinical_ontology.TemporalTag",
+      "parent_entry": "forte.data.ontology.top.Annotation",
+      "description": "A span based annotation `TemporalTag`, used to represent temporal tags of words",
+      "attributes": [
+        {
+          "name": "entity",
+          "type": "str"
+        }
+      ]
+     },
+     {
+      "entry_name": "ftx.medical.clinical_ontology.NormalizedTemporalForm",
+      "parent_entry": "forte.data.ontology.top.Annotation",
+      "description": "A span based annotation `TemporalTag`, used to represent temporal tags of words",
+      "attributes": [
+        {
+          "name": "type",
+          "type": "str"
+        },
+        {
+          "name": "value",
+          "type": "str"
+        }
+      ]
      }
     ]
   }

--- a/ftx/medical/clinical_ontology.py
+++ b/ftx/medical/clinical_ontology.py
@@ -514,7 +514,7 @@ class TemporalTag(Annotation):
 @dataclass
 class NormalizedTemporalForm(Annotation):
     """
-    A span based annotation `TemporalTag`, used to represent temporal tags of words
+    A span based annotation `NormalizedTemporalForm`, used to represent normalized forms of temporal tokens
     Attributes:
         type (Optional[str]):
         value (Optional[str]):

--- a/ftx/medical/clinical_ontology.py
+++ b/ftx/medical/clinical_ontology.py
@@ -1,5 +1,5 @@
 # ***automatically_generated***
-# ***source json:../fortex/health/ontology_specs/clinical_ontology.json***
+# ***source json:ForteHealth/fortex/health/ontology_specs/clinical_ontology.json***
 # flake8: noqa
 # mypy: ignore-errors
 # pylint: skip-file
@@ -47,6 +47,8 @@ __all__ = [
     "MedicalArticle",
     "Abbreviation",
     "Hyponym",
+    "TemporalTag",
+    "NormalizedTemporalForm",
 ]
 
 
@@ -464,7 +466,7 @@ class MedicalArticle(Annotation):
 @dataclass
 class Abbreviation(Annotation):
     """
-    A span based annotation `Abbreviation`, used to represent an abbreviated token..
+    A span based annotation `Abbreviation`, used to represent an abbreviated token
     Attributes:
         long_form (Optional[str]):
     """
@@ -492,3 +494,36 @@ class Hyponym(Link):
     def __init__(self, pack: DataPack, parent: Optional[Entry] = None, child: Optional[Entry] = None):
         super().__init__(pack, parent, child)
         self.hyponym_link: Optional[str] = None
+
+
+@dataclass
+class TemporalTag(Annotation):
+    """
+    A span based annotation `TemporalTag`, used to represent temporal tags of words
+    Attributes:
+        entity (Optional[str]):
+    """
+
+    entity: Optional[str]
+
+    def __init__(self, pack: DataPack, begin: int, end: int):
+        super().__init__(pack, begin, end)
+        self.entity: Optional[str] = None
+
+
+@dataclass
+class NormalizedTemporalForm(Annotation):
+    """
+    A span based annotation `TemporalTag`, used to represent temporal tags of words
+    Attributes:
+        type (Optional[str]):
+        value (Optional[str]):
+    """
+
+    type: Optional[str]
+    value: Optional[str]
+
+    def __init__(self, pack: DataPack, begin: int, end: int):
+        super().__init__(pack, begin, end)
+        self.type: Optional[str] = None
+        self.value: Optional[str] = None


### PR DESCRIPTION
This PR fixes #55 

Added new ontologies for Temporal Tagger and Normalizer.
`TemporalTag` and `NormalizedTemporalForm`.
