### PR TITLE
70 fix abbreviation detector

### DIFF
--- a/fortex/health/processors/scispacy_processor.py
+++ b/fortex/health/processors/scispacy_processor.py
@@ -83,7 +83,9 @@ class ScispaCyProcessor(PackProcessor):
                 list_of_abrvs = []
                 for abrv in doc._.abbreviations:
                     tmp_abrv = Abbreviation(
-                        pack=input_pack, begin=abrv.start_char, end=abrv.end_char
+                        pack=input_pack,
+                        begin=abrv.start_char,
+                        end=abrv.end_char,
                     )
                     tmp_abrv.long_form = abrv._.long_form
                     list_of_abrvs.append(tmp_abrv)

--- a/fortex/health/processors/scispacy_processor.py
+++ b/fortex/health/processors/scispacy_processor.py
@@ -79,12 +79,11 @@ class ScispaCyProcessor(PackProcessor):
         for entry_specified in input_pack.get(entry_type=entry):
 
             doc = self.extractor(entry_specified.text)
-
             if self.configs.pipe_name == "abbreviation_detector":
                 list_of_abrvs = []
                 for abrv in doc._.abbreviations:
                     tmp_abrv = Abbreviation(
-                        pack=input_pack, begin=abrv.start, end=abrv.end
+                        pack=input_pack, begin=abrv.start_char, end=abrv.end_char
                     )
                     tmp_abrv.long_form = abrv._.long_form
                     list_of_abrvs.append(tmp_abrv)

--- a/tests/fortex/health/processors/scispacy_processor_test.py
+++ b/tests/fortex/health/processors/scispacy_processor_test.py
@@ -50,14 +50,15 @@ class TestScispaCyAbvProcessor(unittest.TestCase):
         document = "".join(sentences)
         pack = self.nlp.process(document)
 
-        expected_longform = [
-            "Spinal and bulbar muscular atrophy",
-            "androgen receptor",
-            "Spinal and bulbar muscular atrophy",
+        expected_result = [
+            ("SBMA", "Spinal and bulbar muscular atrophy"),
+            ("AR", "androgen receptor"),
+            ("SBMA", "Spinal and bulbar muscular atrophy"),
         ]
 
         for idx, abv_item in enumerate(pack.get(Abbreviation)):
-            self.assertEqual(abv_item.long_form.text, expected_longform[idx])
+            pipeline_output = (abv_item.text, abv_item.long_form.text)
+            self.assertEqual(pipeline_output, expected_result[idx])
 
 
 class TestScispaCyHyponymProcessor(unittest.TestCase):


### PR DESCRIPTION
This PR fixes #70 . 

### Description of changes
Describe what are the changes, and how they solve the problem.
Change being and end index so that correct short form can be recorded

### Possible influences of this PR.
Describe what are the possible side-effects of the code change.

### Test Conducted
Describe what test cases are included for the PR.
Unittest changed to include both short and long form
